### PR TITLE
order independent dataset hashing

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Make commands:
 * lint
 * wheel
 * docs
+* docs-server
 * black
 
 ## Zeno <zenoml.com> integration

--- a/redlite/_util.py
+++ b/redlite/_util.py
@@ -21,7 +21,7 @@ class DatasetRunningDigest(Sized, Iterable[DatasetItem]):
     """Helper object to compute data digest."""
 
     def __init__(self, dataset: NamedDataset, max_samples=0):
-        self._hash = hashlib.sha256(usedforsecurity=False)
+        self._digest = b'\x00' * 32
         self._dataset = dataset
         self._max_samples = max_samples
 
@@ -29,9 +29,15 @@ class DatasetRunningDigest(Sized, Iterable[DatasetItem]):
         count = 0
         for item in self._dataset:
             yield item
-            self._hash.update(
-                _serialize({"id": item["id"], "messages": item["messages"], "expected": item["expected"]})
-            )
+            record_digest = hashlib.sha256(
+                _serialize({
+                    "id": item["id"],
+                    "messages": item["messages"],
+                    "expected": item["expected"]
+                }),
+                usedforsecurity=False
+            ).digest()
+            self._digest = bytes(a ^ b for a, b in zip(self._digest, record_digest))
             count += 1
             if self._max_samples > 0 and count >= self._max_samples:
                 break
@@ -41,7 +47,7 @@ class DatasetRunningDigest(Sized, Iterable[DatasetItem]):
 
     @property
     def hexdigest(self) -> str:
-        return self._hash.hexdigest()
+        return self._digest.hex()
 
 
 def object_digest(object: list | dict | str | int | float) -> str:

--- a/redlite/_util.py
+++ b/redlite/_util.py
@@ -21,7 +21,7 @@ class DatasetRunningDigest(Sized, Iterable[DatasetItem]):
     """Helper object to compute data digest."""
 
     def __init__(self, dataset: NamedDataset, max_samples=0):
-        self._digest = b'\x00' * 32
+        self._digest = b"\x00" * 32
         self._dataset = dataset
         self._max_samples = max_samples
 
@@ -30,12 +30,8 @@ class DatasetRunningDigest(Sized, Iterable[DatasetItem]):
         for item in self._dataset:
             yield item
             record_digest = hashlib.sha256(
-                _serialize({
-                    "id": item["id"],
-                    "messages": item["messages"],
-                    "expected": item["expected"]
-                }),
-                usedforsecurity=False
+                _serialize({"id": item["id"], "messages": item["messages"], "expected": item["expected"]}),
+                usedforsecurity=False,
             ).digest()
             self._digest = bytes(a ^ b for a, b in zip(self._digest, record_digest))
             count += 1

--- a/redlite/test/test_util.py
+++ b/redlite/test/test_util.py
@@ -60,6 +60,7 @@ ITEM3 = {
     "expected": "MELT",
 }
 
+
 def test_order_independent_dataset_hashing():
     dataset = DatasetRunningDigest(MockDataset(name='mock', data=[ITEM1, ITEM2]))
     for x in dataset:

--- a/redlite/test/test_util.py
+++ b/redlite/test/test_util.py
@@ -62,19 +62,19 @@ ITEM3 = {
 
 
 def test_order_independent_dataset_hashing():
-    dataset = DatasetRunningDigest(MockDataset(name='mock', data=[ITEM1, ITEM2]))
+    dataset = DatasetRunningDigest(MockDataset(name="mock", data=[ITEM1, ITEM2]))
     for x in dataset:
         pass
     digest1 = dataset.hexdigest
 
-    dataset = DatasetRunningDigest(MockDataset(name='mock', data=[ITEM2, ITEM1]))
+    dataset = DatasetRunningDigest(MockDataset(name="mock", data=[ITEM2, ITEM1]))
     for x in dataset:
         pass
     digest2 = dataset.hexdigest
 
     assert digest1 == digest2
 
-    dataset = DatasetRunningDigest(MockDataset(name='mock', data=[ITEM1, ITEM3]))
+    dataset = DatasetRunningDigest(MockDataset(name="mock", data=[ITEM1, ITEM3]))
     for x in dataset:
         pass
     digest3 = dataset.hexdigest

--- a/redlite/test/test_util.py
+++ b/redlite/test/test_util.py
@@ -1,4 +1,6 @@
-from redlite._util import format_duration, parse_duration
+from typing import Iterator
+from redlite import NamedDataset, DatasetItem
+from redlite._util import format_duration, parse_duration, DatasetRunningDigest
 
 
 def test_parse_duration():
@@ -18,3 +20,62 @@ def test_format_duration_float():
 
 def test_parse_duration_float():
     assert parse_duration("1d 0h 0m 0.0s") == 60 * 60 * 24.0
+
+
+class MockDataset(NamedDataset):
+    def __init__(self, *, name, split="test", labels={}, data):
+        self.labels = labels
+        self.data = data
+        self.name = name
+        self.split = split
+
+    def __len__(self) -> int:
+        return len(self.data)
+
+    def __iter__(self) -> Iterator[DatasetItem]:
+        yield from self.data
+
+
+ITEM1 = {
+    "id": "1",
+    "messages": [
+        {"role": "user", "content": "Hello, world!"},
+    ],
+    "expected": "ACCEPT",
+}
+
+ITEM2 = {
+    "id": "2",
+    "messages": [
+        {"role": "user", "content": "Good bye, cruel, world!"},
+    ],
+    "expected": "REJECT",
+}
+
+ITEM3 = {
+    "id": "3",
+    "messages": [
+        {"role": "user", "content": "Is you work boring? Join Innodata!"},
+    ],
+    "expected": "MELT",
+}
+
+def test_order_independent_dataset_hashing():
+    dataset = DatasetRunningDigest(MockDataset(name='mock', data=[ITEM1, ITEM2]))
+    for x in dataset:
+        pass
+    digest1 = dataset.hexdigest
+
+    dataset = DatasetRunningDigest(MockDataset(name='mock', data=[ITEM2, ITEM1]))
+    for x in dataset:
+        pass
+    digest2 = dataset.hexdigest
+
+    assert digest1 == digest2
+
+    dataset = DatasetRunningDigest(MockDataset(name='mock', data=[ITEM1, ITEM3]))
+    for x in dataset:
+        pass
+    digest3 = dataset.hexdigest
+
+    assert digest3 != digest1


### PR DESCRIPTION
Changed hashing algo so that dataset order does not affect the resulting hash. This is to be in sync with
the metric that computes the same summary regardless of the order of items in the dataset.