### PR TITLE
support for (almost) arbitrary HF model params

### DIFF
--- a/redlite/__init__.py
+++ b/redlite/__init__.py
@@ -10,7 +10,7 @@ from ._core import (
 from ._run import run, rescore
 from .dataset._load import load_dataset
 
-__version__ = "0.0.47"
+__version__ = "0.0.48"
 __all__ = [
     "run",
     "rescore",

--- a/redlite/__init__.py
+++ b/redlite/__init__.py
@@ -10,7 +10,7 @@ from ._core import (
 from ._run import run, rescore
 from .dataset._load import load_dataset
 
-__version__ = "0.0.48"
+__version__ = "0.0.49"
 __all__ = [
     "run",
     "rescore",


### PR DESCRIPTION
This PR reworks how `HFModel` is instantiated. Changes are:

1. Removed default `torch_dtype=torch.bfloat16`. To continue using quantized models, set `torch_dtype` parameter in `HFModel` constructor.
2. Removed automatic placement to `cuda:0`. If you want to continue forcing your model to `cuda"0` device, specify `device="cuda:0"` in the constructor
3. Added `device_map` argument (defaults to `None`). May be used to specify model weights placement across multiple accelerator devices.
4. Allowed for arbitrary keyword parameters in `HFModel` constructor, that will be just passed on to the underlying HF model.

Example:

Before:
```
model = HFModel("mistralai/Mistral-7B-v02")
```
Now to achieve the same do this:
```
model = HFModel("mistralai/Mistral-7B-v02", device="cuda", torch_dtype=torch.bfloat16)
```